### PR TITLE
Fixed dead URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dunkman
 🏀A minigame of slam dunk for TIC-80
 
-## [Play Online](https://tic.computer/play?cart=1179)
+## [Play Online](https://tic80.com/play?cart=1179)
 
 ![](https://raw.githubusercontent.com/cxong/Dunkman/master/cover.gif)
 


### PR DESCRIPTION
Hi cxong,

Found a dead URL in the README, caused by a migration on the TIC80 fantasy console's web domain.

Here's a PR with that fix.

Thanks for your time!